### PR TITLE
feat(ruby): Remove conformer 2

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -21,7 +21,3 @@ lib/assemblyai.rb
 lib/assemblyai/transcripts/polling_client.rb
 lib/assemblyai/transcripts/list_by_url_client.rb
 lib/assemblyai/transcripts/types/polling_options.rb
-
-#  Ignore to deprecate conformer-2 option
-lib/assemblyai/transcripts/client.rb
-lib/assemblyai/transcripts/types/speech_model.rb

--- a/lib/assemblyai/transcripts/client.rb
+++ b/lib/assemblyai/transcripts/client.rb
@@ -109,7 +109,6 @@ module AssemblyAI
     # @return [Transcripts::Transcript]
     def submit(audio_url:, speech_model: nil, language_code: nil, punctuate: nil, format_text: nil, dual_channel: nil,
                webhook_url: nil, webhook_auth_header_name: nil, webhook_auth_header_value: nil, auto_highlights: nil, audio_start_from: nil, audio_end_at: nil, word_boost: nil, boost_param: nil, filter_profanity: nil, redact_pii: nil, redact_pii_audio: nil, redact_pii_audio_quality: nil, redact_pii_policies: nil, redact_pii_sub: nil, speaker_labels: nil, speakers_expected: nil, content_safety: nil, content_safety_confidence: nil, iab_categories: nil, language_detection: nil, custom_spelling: nil, disfluencies: nil, sentiment_analysis: nil, auto_chapters: nil, entity_detection: nil, speech_threshold: nil, summarization: nil, summary_model: nil, summary_type: nil, custom_topics: nil, topics: nil, additional_properties: nil, request_options: nil)
-      deprecate_conformer2(speech_model: speech_model)
       response = @request_client.conn.post do |req|
         req.options.timeout = request_options.timeout_in_seconds unless request_options&.timeout_in_seconds.nil?
         req.headers["Authorization"] = request_options.api_key unless request_options&.api_key.nil?
@@ -272,12 +271,6 @@ module AssemblyAI
       end
       Transcripts::RedactedAudioResponse.from_json(json_object: response.body)
     end
-
-    # @param speech_model [Transcripts::SpeechModel]
-    def deprecate_conformer2(speech_model: nil)
-      warn "[DEPRECATION] `conformer-2` is deprecated.  Please use `best` or `nano` instead." if speech_model == "conformer-2"
-    end
-    private :deprecate_conformer2
   end
 
   class AsyncTranscriptsClient
@@ -370,7 +363,6 @@ module AssemblyAI
     # @return [Transcripts::Transcript]
     def submit(audio_url:, speech_model: nil, language_code: nil, punctuate: nil, format_text: nil, dual_channel: nil,
                webhook_url: nil, webhook_auth_header_name: nil, webhook_auth_header_value: nil, auto_highlights: nil, audio_start_from: nil, audio_end_at: nil, word_boost: nil, boost_param: nil, filter_profanity: nil, redact_pii: nil, redact_pii_audio: nil, redact_pii_audio_quality: nil, redact_pii_policies: nil, redact_pii_sub: nil, speaker_labels: nil, speakers_expected: nil, content_safety: nil, content_safety_confidence: nil, iab_categories: nil, language_detection: nil, custom_spelling: nil, disfluencies: nil, sentiment_analysis: nil, auto_chapters: nil, entity_detection: nil, speech_threshold: nil, summarization: nil, summary_model: nil, summary_type: nil, custom_topics: nil, topics: nil, additional_properties: nil, request_options: nil)
-      deprecate_conformer2(speech_model: speech_model)
       Async do
         response = @request_client.conn.post do |req|
           req.options.timeout = request_options.timeout_in_seconds unless request_options&.timeout_in_seconds.nil?
@@ -549,11 +541,5 @@ module AssemblyAI
         Transcripts::RedactedAudioResponse.from_json(json_object: response.body)
       end
     end
-
-    # @param speech_model [Transcripts::SpeechModel]
-    def deprecate_conformer2(speech_model: nil)
-      warn "[DEPRECATION] `conformer-2` is deprecated.  Please use `best` or `nano` instead." if speech_model == "conformer-2"
-    end
-    private :deprecate_conformer2
   end
 end

--- a/lib/assemblyai/transcripts/polling_client.rb
+++ b/lib/assemblyai/transcripts/polling_client.rb
@@ -72,7 +72,6 @@ module AssemblyAI
     # @return [Transcripts::Transcript]
     def transcribe(audio_url:, speech_model: nil, language_code: nil, punctuate: nil, format_text: nil, dual_channel: nil,
                    webhook_url: nil, webhook_auth_header_name: nil, webhook_auth_header_value: nil, auto_highlights: nil, audio_start_from: nil, audio_end_at: nil, word_boost: nil, boost_param: nil, filter_profanity: nil, redact_pii: nil, redact_pii_audio: nil, redact_pii_audio_quality: nil, redact_pii_policies: nil, redact_pii_sub: nil, speaker_labels: nil, speakers_expected: nil, content_safety: nil, content_safety_confidence: nil, iab_categories: nil, language_detection: nil, custom_spelling: nil, disfluencies: nil, sentiment_analysis: nil, auto_chapters: nil, entity_detection: nil, speech_threshold: nil, summarization: nil, summary_model: nil, summary_type: nil, custom_topics: nil, topics: nil, additional_properties: nil, request_options: nil, polling_options: Transcripts::PollingOptions.new)
-      deprecate_conformer2(speech_model: speech_model)
       transcript = submit(audio_url: audio_url, speech_model: speech_model, language_code: language_code, punctuate: punctuate, format_text: format_text, dual_channel: dual_channel,
                           webhook_url: webhook_url, webhook_auth_header_name: webhook_auth_header_name, webhook_auth_header_value: webhook_auth_header_value, auto_highlights: auto_highlights, audio_start_from: audio_start_from, audio_end_at: audio_end_at, word_boost: word_boost, boost_param: boost_param, filter_profanity: filter_profanity, redact_pii: redact_pii, redact_pii_audio: redact_pii_audio, redact_pii_audio_quality: redact_pii_audio_quality, redact_pii_policies: redact_pii_policies, redact_pii_sub: redact_pii_sub, speaker_labels: speaker_labels, speakers_expected: speakers_expected, content_safety: content_safety, content_safety_confidence: content_safety_confidence, iab_categories: iab_categories, language_detection: language_detection, custom_spelling: custom_spelling, disfluencies: disfluencies, sentiment_analysis: sentiment_analysis, auto_chapters: auto_chapters, entity_detection: entity_detection, speech_threshold: speech_threshold, summarization: summarization, summary_model: summary_model, summary_type: summary_type, custom_topics: custom_topics, topics: topics, additional_properties: additional_properties, request_options: request_options)
       wait_until_ready(transcript_id: transcript.id, polling_options: polling_options)
@@ -97,13 +96,6 @@ module AssemblyAI
         sleep polling_options.interval / 1000
       end
     end
-
-    # @param speech_model [Transcripts::SpeechModel]
-    def deprecate_conformer2(speech_model: nil)
-      warn "[DEPRECATION] `conformer-2` is deprecated.  Please use `best` or `nano` instead." if speech_model == "conformer-2"
-    end
-
-    private :deprecate_conformer2
   end
 
   # :nodoc:
@@ -157,7 +149,6 @@ module AssemblyAI
     # @return [Transcripts::Transcript]
     def transcribe(audio_url:, speech_model: nil, language_code: nil, punctuate: nil, format_text: nil, dual_channel: nil,
                    webhook_url: nil, webhook_auth_header_name: nil, webhook_auth_header_value: nil, auto_highlights: nil, audio_start_from: nil, audio_end_at: nil, word_boost: nil, boost_param: nil, filter_profanity: nil, redact_pii: nil, redact_pii_audio: nil, redact_pii_audio_quality: nil, redact_pii_policies: nil, redact_pii_sub: nil, speaker_labels: nil, speakers_expected: nil, content_safety: nil, content_safety_confidence: nil, iab_categories: nil, language_detection: nil, custom_spelling: nil, disfluencies: nil, sentiment_analysis: nil, auto_chapters: nil, entity_detection: nil, speech_threshold: nil, summarization: nil, summary_model: nil, summary_type: nil, custom_topics: nil, topics: nil, additional_properties: nil, request_options: nil, polling_options: Transcripts::PollingOptions.new)
-      deprecate_conformer2(speech_model: speech_model)
       Async do
         transcript = submit(audio_url: audio_url, speech_model: speech_model, language_code: language_code, punctuate: punctuate, format_text: format_text, dual_channel: dual_channel,
                             webhook_url: webhook_url, webhook_auth_header_name: webhook_auth_header_name, webhook_auth_header_value: webhook_auth_header_value, auto_highlights: auto_highlights, audio_start_from: audio_start_from, audio_end_at: audio_end_at, word_boost: word_boost, boost_param: boost_param, filter_profanity: filter_profanity, redact_pii: redact_pii, redact_pii_audio: redact_pii_audio, redact_pii_audio_quality: redact_pii_audio_quality, redact_pii_policies: redact_pii_policies, redact_pii_sub: redact_pii_sub, speaker_labels: speaker_labels, speakers_expected: speakers_expected, content_safety: content_safety, content_safety_confidence: content_safety_confidence, iab_categories: iab_categories, language_detection: language_detection, custom_spelling: custom_spelling, disfluencies: disfluencies, sentiment_analysis: sentiment_analysis, auto_chapters: auto_chapters, entity_detection: entity_detection, speech_threshold: speech_threshold, summarization: summarization, summary_model: summary_model, summary_type: summary_type, custom_topics: custom_topics, topics: topics, additional_properties: additional_properties, request_options: request_options).wait
@@ -186,12 +177,5 @@ module AssemblyAI
         end
       end
     end
-
-    # @param speech_model [Transcripts::SpeechModel]
-    def deprecate_conformer2(speech_model:)
-      warn "[DEPRECATION] `conformer-2` is deprecated.  Please use `best` or `nano` instead." if speech_model == "conformer-2"
-    end
-
-    private :deprecate_conformer2
   end
 end

--- a/lib/assemblyai/transcripts/types/speech_model.rb
+++ b/lib/assemblyai/transcripts/types/speech_model.rb
@@ -6,8 +6,6 @@ module AssemblyAI
     class SpeechModel
       BEST = "best"
       NANO = "nano"
-      # @deprecated This option will stop working in the near future. Please use {#BEST} or {#NANO} instead
-      CONFORMER2 = "conformer-2"
     end
   end
 end

--- a/lib/gemconfig.rb
+++ b/lib/gemconfig.rb
@@ -2,7 +2,7 @@
 
 module AssemblyAI
   module Gemconfig
-    VERSION = "1.0.0-beta.16"
+    VERSION = "1.0.0-beta.17"
     AUTHORS = [""].freeze
     EMAIL = "support@assemblyai.com"
     SUMMARY = "AssemblyAI Ruby SDK"


### PR DESCRIPTION
# **Remove conformer-2**

This would normally be a breaking change, but the API already stopped accepting `conformer-2` as an option, so it doesn't work anymore anyways.
This removes `conformer-2` from the speech model enum.